### PR TITLE
normalize xdebug path

### DIFF
--- a/phpfpm/5.5/Dockerfile
+++ b/phpfpm/5.5/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
 RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
-	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/5.5/Dockerfile
+++ b/phpfpm/5.5/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
-RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+RUN XDEBUG=$(find /usr/local/lib/php -name 'xdebug.so' | head -n 1 | tail -n 1) \
 	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]

--- a/phpfpm/5.5/Dockerfile
+++ b/phpfpm/5.5/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
+	
+RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/5.6/Dockerfile
+++ b/phpfpm/5.6/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
 RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
-	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/5.6/Dockerfile
+++ b/phpfpm/5.6/Dockerfile
@@ -21,6 +21,9 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
+	
+RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/5.6/Dockerfile
+++ b/phpfpm/5.6/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
-RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+RUN XDEBUG=$(find /usr/local/lib/php -name 'xdebug.so' | head -n 1 | tail -n 1) \
 	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]

--- a/phpfpm/7.0/Dockerfile
+++ b/phpfpm/7.0/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
 RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
-	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/7.0/Dockerfile
+++ b/phpfpm/7.0/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
-RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+RUN XDEBUG=$(find /usr/local/lib/php -name 'xdebug.so' | head -n 1 | tail -n 1) \
 	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]

--- a/phpfpm/7.0/Dockerfile
+++ b/phpfpm/7.0/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
+	
+RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/7.1/Dockerfile
+++ b/phpfpm/7.1/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
 RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
-	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/7.1/Dockerfile
+++ b/phpfpm/7.1/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 	
-RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+RUN XDEBUG=$(find /usr/local/lib/php -name 'xdebug.so' | head -n 1 | tail -n 1) \
 	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]

--- a/phpfpm/7.1/Dockerfile
+++ b/phpfpm/7.1/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y \
 	&& apt-get clean \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
+	
+RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/7.2/Dockerfile
+++ b/phpfpm/7.2/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 
-RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+RUN XDEBUG=$(find /usr/local/lib/php -name 'xdebug.so' | head -n 1 | tail -n 1) \
 	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]

--- a/phpfpm/7.2/Dockerfile
+++ b/phpfpm/7.2/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 	&& chown www-data:www-data /var/www/.wp-cli
 
 RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
-	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+	&& ln -s $XDEBUG /usr/local/lib/php/extensions/xdebug.so
 
 CMD ["php-fpm"]
 

--- a/phpfpm/7.2/Dockerfile
+++ b/phpfpm/7.2/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update && apt-get install -y \
 	&& mkdir /var/www/.wp-cli \
 	&& chown www-data:www-data /var/www/.wp-cli
 
+RUN XDEBUG=$(find / -name 'xdebug.so' | head -n 1 | tail -n 1) \
+	&& cp $XDEBUG /usr/local/lib/php/extensions/xdebug.so
+
 CMD ["php-fpm"]
 
 EXPOSE 9000


### PR DESCRIPTION
The pecl installation of xdebug places the binary in a timestamped folder in `/usr/local/lib/php/extensions/no-debug-non-zts-XXXXXXX/` the timestamp, if I understand correctly, reflect the PHP builds being used.

This makes it so that the reference to it on `docker-php-ext-xdebug.ini` needs to be frequently updated and can fall out of sync if a project changes PHP versions, or even if it simply updates wp-local-docker. (see https://github.com/10up/wp-local-docker/pull/86 and https://github.com/10up/wp-local-docker/issues/110)

This adds a workaround for the issue in the build process by creating a copy of `xdebug.so` in the parent folder. Which can then be referenced in the config.