### PR TITLE
Updating PHPUnit download URL to match the correct version for PHP 7.0

### DIFF
--- a/phpfpm/7.0/Dockerfile
+++ b/phpfpm/7.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM johnpbloch/phpfpm:7.0
 
-RUN curl -L https://phar.phpunit.de/phpunit.phar > /tmp/phpunit.phar \
+RUN curl -L https://phar.phpunit.de/phpunit-6.phar > /tmp/phpunit.phar \
 	&& chmod +x /tmp/phpunit.phar \
 	&& mv /tmp/phpunit.phar /usr/local/bin/phpunit
 


### PR DESCRIPTION
Hey guys, just a small fix to keep things running.
Newer PHPUnit 7.x versions does not support PHP 7.0

https://phpunit.de/getting-started/phpunit-7.html

edit: @cmmarslender ping