### PR TITLE
use :0.7.0 for the jwilder/nginx-proxy container, rather than latest

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:0.7.0
 
 COPY certs/ /etc/nginx/certs
 COPY nginx.tmpl /app/nginx.tmpl


### PR DESCRIPTION
fixes #16 